### PR TITLE
prevent starvation of the event loop under heavy load

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -122,7 +122,9 @@ Client.prototype.connect = function(cb) {
           self.emit('connect');
           self._connectWaitQueue.forEach(function(callback) {
             try {
-              self.getAvailableConnection(callback);
+              setImmediate(function(){
+                self.getAvailableConnection(callback);
+              })
             } catch (e) {
               self.emit('error', e);
             }


### PR DESCRIPTION
found that when attempting to open a number of client connections greater that the pool size, the getAvailableConnection call was blocking the event loop
