### PR TITLE
Node v0.12.x support

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -98,7 +98,7 @@ Connection.prototype.available = function() {
 
 /**
  * Connect to the server.
- * @param {errorCallback} cb 
+ * @param {errorCallback} cb
  */
 Connection.prototype.connect = function(cb) {
 
@@ -157,7 +157,7 @@ Connection.prototype.connect = function(cb) {
     for (var i = 127; i > 0; i--) {
       self._streamIds.push(i);
     }
-    
+
     delete self._socket;
     // auto reconnect
     if (!self._shutdown && self._autoReconnect) {
@@ -221,6 +221,17 @@ Connection.prototype.connect = function(cb) {
     });
   });
   protocol.on('message', this.receiveMessage.bind(this));
+
+  if (!protocol.listeners('readable').length) {
+    protocol.on('readable', function() {
+      var state = protocol._readableState;
+      state.ranOut = false;
+      var chunk;
+      do {
+        chunk = protocol.read();
+      } while (null !== chunk && state.flowing);
+    });
+  }
 
   // Connect  time out
   this._connectTimeoutId = setTimeout(function() {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "codecov.io": "0.0.2",
     "expect.js": "^0.2.0",
     "istanbul": "^0.2.6",
-    "mocha": "^1.14.0",
+    "mocha": "^2.1.0",
     "mocha-lcov-reporter": "^0.0.1"
   },
   "config": {

--- a/test/test.protocol.js
+++ b/test/test.protocol.js
@@ -10,6 +10,17 @@ describe('test ser/de messages', function() {
 
   serde.pipe(serde);
 
+  if (!serde.listeners('readable').length) {
+    serde.on('readable', function() {
+      var state = serde._readableState;
+      state.ranOut = false;
+      var chunk;
+      do {
+        chunk = serde.read();
+      } while (null !== chunk && state.flowing);
+    });
+  }
+
   it('messages.Error', function(done) {
     var message = new protocol.messages.Error(0x0000, 'Server error');
     expect(message.opcode).to.eql(0x00)


### PR DESCRIPTION
node v0.12ではreadable_streamのdefaultのreadableイベントが登録されないため登録するようにしました。
またmocha v1.Xはchild_processでduplicateされたcustomFdsを使用しているため2系にあげています。

ご確認お願い致します。
